### PR TITLE
[ABC-651] Make JSonResponse method compatible with Django 1.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 Changes
 =======
+v0.2.0 - 08/06/2017
+* JSonResponse Django native method will be used for 1.7 version
+* JSonResponse method encoder changed to DjangoJSONEncoder
+* Deprecated Mime-Type HTTP header changed to Content-Type header
+
+
 v0.1.1 - 12/06/2015
  * Minor changes in packaging and readme.
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 Contributors
 ============
  * Ebury
+ * Rafa Martos (elbuenodefali)

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Django Health Check Plus
 ========================
 
-:Version: 0.1.1
+:Version: 0.2.0
 :Status: beta
 :Author: Miguel Angel Moreno
 

--- a/health_check_plus/__init__.py
+++ b/health_check_plus/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '0.1.1'
+__version__ = '0.2.0'
 __license__ = 'GPLv3'
 
 __author__ = 'Miguel Angel Moreno'

--- a/health_check_plus/views.py
+++ b/health_check_plus/views.py
@@ -1,7 +1,9 @@
-from health_check_plus import settings
-from health_check_plus.utils import JsonResponse
 from health_check.plugins import plugin_dir
 from health_check.views import home
+
+from health_check_plus import settings
+from health_check_plus.utils import JsonResponse
+
 
 def main(request):
     format = request.GET.get('format', None)
@@ -10,8 +12,8 @@ def main(request):
     elif format == "json":
         return main_json(request)
 
-def main_json(request):
 
+def main_json(request):
     whitelist = set(settings.HEALTH_CHECK_PLUGINS.values())
 
     str_filter = request.GET.get('checks', None)
@@ -53,6 +55,6 @@ def main_json(request):
         raise Exception("Some check plugin configured but not loaded")
 
     if working:
-        return JsonResponse(plugins)
+        return JsonResponse(plugins, safe=False)
     else:
-        return JsonResponse(plugins, status=500)
+        return JsonResponse(plugins, status=500, safe=False)


### PR DESCRIPTION
Changes:
* JSonResponse Django native method will be used for 1.7 version
* JSonResponse method encoder changed to DjangoJSONEncoder
* Deprecated Mime-Type HTTP header changed to Content-Type header

Please check this PR too:
@AbrahamGo8
@amatellanes
@JuanMiGabarron
