### PR TITLE
Fix custom health checks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 Changes
 =======
+v1.0.1 - 02/08/2018
+* Fix optional check view not detecting custom health checks.
+
 v1.0.0 - 11/08/2017
 * Upgrade to Django 1.11, python3 and `django-health-check` 2.3.0
 * [Breaking change] Removed old functionality and remove old Django version compatibility.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,3 +3,4 @@ Contributors
  * Ebury
  * Rafa Martos (elbuenodefali)
  * [Rubén Pardo](https://github.com/wen96/)
+ * [David Peinado](https://github.com/peinad0/)

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Django Health Check Plus
 ========================
 
-:Version: 1.0.0
+:Version: 1.0.1
 :Author: Miguel Angel Moreno
 
 Django package to improve usage of django-health-check library.
@@ -25,13 +25,7 @@ Include in settings.py the next settings::
                         ...
                       )
 
-Include the next variable in settings.py::
-
-    HEALTH_CHECK_PLUGINS = {
-        'name': 'plugin_identifier'
-    }
-
-Where name is set by user and plugin_identifier es the identifier given by health_check library for every plugin.
+Where name is set by user and plugin_identifier is the identifier given by health_check library for every plugin.
 
 Example::
 
@@ -45,10 +39,6 @@ Example::
                         ...
                       )
 
-    HEALTH_CHECK_PLUGINS = {
-        'happy': 'MyServiceIsHappyCheck',
-    }
-
 Include the next line in urlpatterns variable in urls.py::
 
     url(r'^status/', include('health_check_plus.urls')),
@@ -57,7 +47,7 @@ Include the next line in urlpatterns variable in urls.py::
 Add new check
 =============
 
-riting a health check is quick and easy:
+Writing a health check is quick and easy:
 
 .. code:: python
 
@@ -72,7 +62,9 @@ riting a health check is quick and easy:
             pass
 
         def identifier(self):
-            return self.__class__.__name__  # Display name on the endpoint.
+            # Might be overridden if you want to get a custom name, otherwise
+            # the checker class name will be used.
+            return self.__class__.__name__
 
 After writing a custom checker, register it in your app configuration:
 
@@ -90,14 +82,6 @@ After writing a custom checker, register it in your app configuration:
             plugin_dir.register(MyHealthCheckBackend)
 
 Make sure the application you write the checker into is registered in your ``INSTALLED_APPS``.
-
-Finally add your plugin class to ``HEALTH_CHECK_PLUGINS``:
-
-.. code:: python
-
-        HEALTH_CHECK_PLUGINS = {
-            'myhealthcheck': 'MyHealthCheckBackend',
-        }
 
 Usage
 =====
@@ -123,4 +107,4 @@ To show status of some checks (mycheck1 and mycheck2) in json format use::
 HTTP status code:
 
  * 200: If all queried checks are in status OK.
- * 500: If some queried check is WRONG.
+ * 500: If any queried check is WRONG.

--- a/health_check_plus/tests.py
+++ b/health_check_plus/tests.py
@@ -2,8 +2,28 @@ from django.conf import settings
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from health_check.backends import BaseHealthCheckBackend
+from health_check.exceptions import ServiceUnavailable
+from health_check.plugins import plugin_dir
+
 
 class StatusOptionalCheckViewTest(TestCase):
+    class ServiceDownCustomHealthCheck(BaseHealthCheckBackend):
+        def check_status(self):
+            raise ServiceUnavailable('Testing service not working')
+
+    class ServiceUpCustomHealthCheck(BaseHealthCheckBackend):
+        def check_status(self):
+            pass
+
+    class ServiceUpOverriddenIdentifierCustomHealthCheck(BaseHealthCheckBackend):
+        def check_status(self):
+            pass
+
+        @staticmethod
+        def identifier():
+            return 'test_check'
+
     url = reverse('health_optional_check')
 
     def test_query_url_with_not_params_returns_html(self):
@@ -40,6 +60,46 @@ class StatusOptionalCheckViewTest(TestCase):
 
         self.assertEqual(result.status_code, 500)
         self.assertEqual(result.json()['DatabaseBackend'], 'unavailable: Database error')
+
+    def test_custom_health_check_not_failing(self):
+        plugin_dir.register(self.ServiceUpCustomHealthCheck)
+
+        result = self.client.get('{}?format=json&checks=ServiceUpCustomHealthCheck'.format(self.url))
+
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.json(), {'ServiceUpCustomHealthCheck': 'working'})
+
+    def test_custom_health_check_failing(self):
+        plugin_dir.register(self.ServiceDownCustomHealthCheck)
+
+        result = self.client.get('{}?format=json&checks=ServiceDownCustomHealthCheck'.format(self.url))
+
+        self.assertEqual(result.status_code, 500)
+        self.assertEqual(result.json(), {'ServiceDownCustomHealthCheck': 'unavailable: Testing service not working'})
+
+    def test_custom_health_overridden_identifier_check_not_failing(self):
+        plugin_dir.register(self.ServiceUpOverriddenIdentifierCustomHealthCheck)
+
+        result = self.client.get('{}?format=json&checks=test_check'.format(self.url))
+
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.json(), {'test_check': 'working'})
+
+    def test_two_custom_health_check_one_down_other_up(self):
+        plugin_dir.register(self.ServiceUpCustomHealthCheck)
+        plugin_dir.register(self.ServiceDownCustomHealthCheck)
+
+        result = self.client.get(
+            '{}?format=json&checks=ServiceUpCustomHealthCheck,ServiceDownCustomHealthCheck'.format(self.url))
+
+        self.assertEqual(result.status_code, 500)
+        self.assertEqual(
+            result.json(),
+            {
+                'ServiceDownCustomHealthCheck': 'unavailable: Testing service not working',
+                'ServiceUpCustomHealthCheck': 'working'
+            }
+        )
 
 
 class StatusCheckPingViewTest(TestCase):

--- a/health_check_plus/views.py
+++ b/health_check_plus/views.py
@@ -33,7 +33,7 @@ class StatusOptionalCheckView(MainView):
     def _plugin_in_queryparams(self, request, plugin):
         if 'checks' in request.GET:
             plugins_to_check = request.GET.get('checks', '').split(',')
-            return self.humanize_plugin_name.get(plugin.identifier()) in plugins_to_check
+            return self.humanize_plugin_name.get(plugin.identifier(), plugin.identifier()) in plugins_to_check
         return True
 
 


### PR DESCRIPTION
Custom checks are not being detected on version 1.0.0, that is because the setting documented in the README (HEALTH_CHECK_PLUGINS) is not being used any more.

Changes of this PR:

1. Fix `_plugin_in_queryparams` function to get the plugin identifier by default if it is not present in the `humanize_plugin_name` dict.
2. Add tests to check if custom plugins implementations are working.
3. Updated documentation to remove old settings configurations.

Main change is to set a default plugin humanized name when it is not present in the `humanize_plugin_name` dict:

```
# Previously:
return self.humanize_plugin_name.get(plugin.identifier()) in plugins_to_check

# Now:
return self.humanize_plugin_name.get(plugin.identifier(), plugin.identifier()) in plugins_to_check
```