### PR TITLE
ONL-5595: chore: Updated dependency django-health-check to support Django 3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 Changes
 =======
+v2.0.0 - 13/05/2021
+* Update required `django-health-check` to v3.16.4 so it could support Django 3.
+
 v1.0.1 - 02/08/2018
 * Fix optional check view not detecting custom health checks.
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Django Health Check Plus
 ========================
 
-:Version: 1.0.1
+:Version: 2.0.0
 :Author: Miguel Angel Moreno
 
 Django package to improve usage of django-health-check library.

--- a/health_check_plus/__init__.py
+++ b/health_check_plus/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '1.0.2'
+__version__ = '2.0.0'
 __license__ = 'GPLv3'
 
 __author__ = 'Miguel Angel Moreno'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-django-health-check==2.3.0
+django-health-check==3.16.4

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'health_check_plus',
     ],
     include_package_data=True,
-    install_requires=['django-health-check==2.3.0'],
+    install_requires=['django-health-check==3.16.4'],
     license=health_check_plus.__license__,
     zip_safe=False,
     keywords='python, django, health, check, network, service',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36}-dj{111}
+envlist = py{36}-dj{111,22,30}
 
 [testenv]
 setenv=
@@ -7,6 +7,8 @@ setenv=
 deps=
     -rrequirements-dev.txt
     dj111: Django==1.11
+    dj22: Django==2.2.23
+    dj30: Django==3.2.3
 commands=
     coverage run --source=health_check_plus runtest.py
     coverage report


### PR DESCRIPTION
In order to run this library with Django 3, we need to update the django-health-check dependency to 3.16.4.