### PR TITLE
Feature/onl 5595 build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
 env:
   matrix:
   - DJANGO=111
+  - DJANGO=22
+  - DJANGO=32
 install:
 - pip install --upgrade tox
 before_script:

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ Django Health Check Plus
 
 Django package to improve usage of django-health-check library.
 
+Use `django-health-check==3.16.3` if you'd like to install this library in Django 1.11 project. For Django 2 and 3 use `django-health-check==3.16.4`.
+
 Install
 =======
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-django-health-check==3.16.4
+django-health-check>=3.16.3,<=3.16.4

--- a/runtest.py
+++ b/runtest.py
@@ -6,6 +6,7 @@ from django.test.runner import DiscoverRunner
 
 settings.configure(
     DEBUG=True,
+    SECRET_KEY='secret_key',
     ROOT_URLCONF='health_check_plus.urls',
     INSTALLED_APPS=[
        'django.contrib.auth',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'health_check_plus',
     ],
     include_package_data=True,
-    install_requires=['django-health-check==3.16.4'],
+    install_requires=['django-health-check>=3.16.3,<=3.16.4'],
     license=health_check_plus.__license__,
     zip_safe=False,
     keywords='python, django, health, check, network, service',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36}-dj{111,22,30}
+envlist = py{36}-dj{111,22,32}
 
 [testenv]
 setenv=
@@ -8,7 +8,7 @@ deps=
     -rrequirements-dev.txt
     dj111: Django==1.11
     dj22: Django==2.2.23
-    dj30: Django==3.2.3
+    dj32: Django==3.2.3
 commands=
     coverage run --source=health_check_plus runtest.py
     coverage report


### PR DESCRIPTION
Fixed issues with the build. We need to enable two versions of django-health-check to be installed with this library, the version 3.16.3 when using Django 1 and 3.16.4 when using Django 2 and 3.

